### PR TITLE
Rename Type -> Types to avoid confusion with 'type'

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,12 @@
-# readinweb-elm
-Elm app for Read in Web course
+# MupiPro Front End App
+Elm app for MupiPro project
+
+Requirements: `npm`, `gulp`, `nodejs`, `elm`
+
+Install the dependencies with `npm install`
+
+After installing the dependencies, run `elm-make` to compile.
+
+To run the server and the app run:
+
+`gulp`

--- a/src/Login/Rest.elm
+++ b/src/Login/Rest.elm
@@ -3,7 +3,7 @@ module Login.Rest exposing (..)
 import Http exposing (..)
 import Json.Decode as Decode exposing (field)
 import Json.Encode as Encode exposing (Value, encode, object, string)
-import Login.Type exposing (..)
+import Login.Types exposing (..)
 import User.Rest as User
 
 

--- a/src/Login/State.elm
+++ b/src/Login/State.elm
@@ -1,7 +1,7 @@
 module Login.State exposing (init, update)
 
 import Http
-import Login.Type exposing (..)
+import Login.Types exposing (..)
 import Login.Rest exposing (..)
 import User.State as User
 

--- a/src/Login/Types.elm
+++ b/src/Login/Types.elm
@@ -1,7 +1,7 @@
-module Login.Type exposing (..)
+module Login.Types exposing (..)
 
 import Http
-import User.Type as User
+import User.Types as User
 
 
 type alias Model =

--- a/src/Login/View.elm
+++ b/src/Login/View.elm
@@ -3,7 +3,7 @@ module Login.View exposing (..)
 import Html exposing (..)
 import Html.Attributes exposing (id, type_, for, value, class)
 import Html.Events exposing (..)
-import Login.Type exposing (..)
+import Login.Types exposing (..)
 
 
 -- import State exposing (..)

--- a/src/Main.elm
+++ b/src/Main.elm
@@ -2,7 +2,7 @@ module Main exposing (..)
 
 import View exposing (view)
 import State exposing (init, update, subscriptions)
-import Type exposing (Model, Msg(..))
+import Types exposing (Model, Msg(..))
 import Navigation exposing (program)
 
 

--- a/src/State.elm
+++ b/src/State.elm
@@ -1,6 +1,6 @@
 module State exposing (init, update, subscriptions)
 
-import Type exposing (..)
+import Types exposing (..)
 import Navigation exposing (Location)
 import User.State as User
 import Login.State as Login

--- a/src/Types.elm
+++ b/src/Types.elm
@@ -1,9 +1,9 @@
-module Type exposing (..)
+module Types exposing (..)
 
 import Navigation exposing (Location)
 import Routing
-import User.Type as User
-import Login.Type as Login
+import User.Types as User
+import Login.Types as Login
 
 
 type alias Model =

--- a/src/User/Rest.elm
+++ b/src/User/Rest.elm
@@ -2,7 +2,7 @@ module User.Rest exposing (..)
 
 import Http
 import Json.Decode as Decode exposing (field)
-import User.Type exposing (Model)
+import User.Types exposing (Model)
 
 
 usersDecoder : Decode.Decoder (List Model)

--- a/src/User/State.elm
+++ b/src/User/State.elm
@@ -1,6 +1,6 @@
 module User.State exposing (init, update)
 
-import User.Type exposing (..)
+import User.Types exposing (..)
 
 
 init : Model

--- a/src/User/Types.elm
+++ b/src/User/Types.elm
@@ -1,4 +1,4 @@
-module User.Type exposing (..)
+module User.Types exposing (..)
 
 
 type alias Model =

--- a/src/User/View.elm
+++ b/src/User/View.elm
@@ -3,7 +3,7 @@ module User.View exposing (..)
 import Html exposing (..)
 import Html.Attributes exposing (id, type_, for, value, class)
 import Html.Events exposing (..)
-import User.Type exposing (..)
+import User.Types exposing (..)
 
 
 -- import State exposing (..)

--- a/src/View.elm
+++ b/src/View.elm
@@ -3,7 +3,7 @@ module View exposing (..)
 import Html exposing (..)
 import Html.Attributes exposing (..)
 import Html.Events exposing (..)
-import Type exposing (..)
+import Types exposing (..)
 import Login.View as Login
 import User.View as User
 import Routing exposing (Route(..))


### PR DESCRIPTION
Rename all files Type.elm to Types.elm as well as their modules.
Also update README with some installation info.